### PR TITLE
Config for SKR PRO 1.1 + MOT

### DIFF
--- a/firmware/klipper_configurations/SKR Pro 1.1 + MOT.cfg
+++ b/firmware/klipper_configurations/SKR Pro 1.1 + MOT.cfg
@@ -1,0 +1,647 @@
+[include client.cfg]
+[include client_macros.cfg]
+# This file contains common pin mappings for the BigTreeTech SKR PRO.
+# To use this config, the firmware should be compiled for the
+# STM32F407 with a "32KiB bootloader".
+#~
+
+# The "make flash" command does not work on the SKR PRO. Instead,
+# after running "make", copy the generated "out/klipper.bin" file to a
+# file named "firmware.bin" on an SD card and then restart the SKR PRO
+# with that SD card.
+
+# See docs/Config_Reference.md for a description of parameters.
+
+## *** THINGS TO CHANGE/CHECK: ***
+## MCU paths							[mcu] section
+## Thermistor types						[extruder] and [heater_bed] sections - See 'sensor types' list at end of file
+## Z Endstop Switch location			[safe_z_home] section
+## Homing end position				[gcode_macro G32] section
+## Z Endstop Switch  offset for Z0		[stepper_z] section
+## Probe points							[quad_gantry_level] section
+## Min & Max gantry corner postions		[quad_gantry_level] section
+## PID tune								[extruder] and [heater_bed] sections
+## Fine tune E steps					[extruder] section
+
+############################################
+# Printer
+############################################
+
+##	[X in X] - B Motor
+##	[Y in Y] - A Motor
+##	[E in E0] - Extruder
+
+[printer]
+kinematics: corexy
+max_velocity: 150   
+max_accel: 9000
+max_accel_to_decel: 9000
+max_z_velocity: 30
+max_z_accel: 100
+
+###########################################
+# Steppers
+###########################################
+
+[stepper_x]
+step_pin: PE9
+dir_pin: PF1
+enable_pin: !PF2
+microsteps: 16
+rotation_distance: 40
+full_steps_per_rotation:400 #.9degree
+#endstop_pin: PB10
+endstop_pin: tmc5160_stepper_x:virtual_endstop
+position_endstop: 300
+position_min: 0
+position_max: 300
+homing_speed: 50
+homing_retract_dist: 0
+
+[stepper_y]
+step_pin: PE11
+dir_pin: PE8
+enable_pin: !PD7
+microsteps: 16
+rotation_distance: 40
+full_steps_per_rotation:400 #.9degree
+#endstop_pin: PE12
+endstop_pin: tmc5160_stepper_y:virtual_endstop
+position_endstop: 300
+position_min: 0
+position_max: 300
+homing_speed: 50
+homing_retract_dist: 0
+
+[stepper_z]
+step_pin: PE13
+dir_pin: !PC2
+enable_pin: !PC0
+microsteps: 16
+rotation_distance: 40
+gear_ratio: 80:16
+endstop_pin: PG8
+position_endstop: 6.4 #5.0 #-0.5
+position_max: 290
+position_min: -5
+homing_speed: 8
+second_homing_speed: 3
+homing_retract_dist: 3
+
+[stepper_z1]
+step_pin: PD15
+dir_pin: PE7
+enable_pin: !PA3
+microsteps: 16
+rotation_distance: 40
+gear_ratio: 80:16
+#heater_pin: PD14 # Heat1
+#sensor_pin: PF5 # T2
+#...
+
+[stepper_z2]
+step_pin: PD13
+dir_pin: !PG9
+enable_pin: !PF0
+microsteps: 16
+rotation_distance: 40
+gear_ratio: 80:16
+#heater_pin: PB0 # Heat2
+#sensor_pin: PF6 # T3
+#...
+
+#Config for the BTT mot-exp
+#See docs/Config_Reference.md for a description of parameters.
+
+[stepper_z3]
+step_pin: EXP2_6
+dir_pin: !EXP2_5
+enable_pin: !EXP2_7
+microsteps: 16
+rotation_distance: 40
+gear_ratio: 80:16
+
+#[stepper_2]
+#step_pin: EXP2_3
+#dir_pin: EXP2_4
+#enable_pin: !EXP1_8
+#microsteps: 16
+#rotation_distance: 40
+
+#[stepper_3]
+#step_pin: EXP2_1
+#dir_pin: EXP2_2
+#enable_pin: !EXP1_7
+#microsteps: 16
+#rotation_distance: 8
+#position_endstop: 0.5
+
+########################################
+# TMC2208 configuration
+########################################
+
+#[tmc2208 stepper_x]
+#uart_pin: PC13
+#run_current: 0.800
+#hold_current: 0.500
+#stealthchop_threshold: 250
+
+#[tmc2208 stepper_y]
+#uart_pin: PE3
+#run_current: 0.800
+#hold_current: 0.500
+#stealthchop_threshold: 250
+
+[tmc2208 stepper_z]
+uart_pin: PE1
+run_current: 0.800
+hold_current: 0.500
+stealthchop_threshold: 5
+
+#[tmc2208 extruder]
+#uart_pin: PD4
+#run_current: 0.800
+#hold_current: 0.500
+#stealthchop_threshold: 5
+
+[tmc2208 stepper_z1] #extruder1
+uart_pin: PD1
+run_current: 0.800
+hold_current: 0.500
+stealthchop_threshold: 5
+
+[tmc2208 stepper_z2] #extruder2
+uart_pin: PD6
+run_current: 0.800
+hold_current: 0.500
+stealthchop_threshold: 5
+
+[tmc2208 stepper_z3] #stepper_1
+uart_pin: EXP1_6
+run_current: 0.800
+hold_current: 0.500
+stealthchop_threshold: 250
+#diag_pin: EXP1_5
+
+#[tmc2208 stepper_2]
+#uart_pin: EXP1_4
+#microsteps: 16
+#run_current: 0.800
+#hold_current: 0.500
+#stealthchop_threshold: 250
+#diag_pin: EXP1_3
+
+#[tmc2208 stepper_3]
+#uart_pin: EXP1_2
+#microsteps: 16
+#run_current: 0.650
+#hold_current: 0.450
+#stealthchop_threshold: 30
+#diag_pin: EXP1_1
+
+########################################
+# TMC2130 configuration
+########################################
+
+#[tmc2130 stepper_x]
+#cs_pin: PA15
+#spi_bus: spi3a
+##diag1_pin: PB10
+#run_current: 0.800
+#hold_current: 0.500
+#stealthchop_threshold: 250
+
+#[tmc2130 stepper_y]
+#cs_pin: PB8
+#spi_bus: spi3a
+##diag1_pin: PE12
+#run_current: 0.800
+#hold_current: 0.500
+#stealthchop_threshold: 250
+
+#[tmc2130 stepper_z]
+#cs_pin: PB9
+#spi_bus: spi3a
+##diag1_pin: PG8
+#run_current: 0.650
+#hold_current: 0.450
+#stealthchop_threshold: 30
+
+#[tmc2130 extruder]
+#cs_pin: PB3
+#spi_bus: spi3a
+##diag1_pin: PE15
+#run_current: 0.800
+#hold_current: 0.500
+#stealthchop_threshold: 5
+
+#[tmc2130 extruder1]
+#cs_pin: PG15
+#spi_bus: spi3a
+##diag1_pin: PE10
+#run_current: 0.800
+#hold_current: 0.500
+#stealthchop_threshold: 5
+
+#[tmc2130 extruder2]
+#cs_pin: PG12
+#spi_bus: spi3a
+##diag1_pin: PG5
+#run_current: 0.800
+#hold_current: 0.500
+#stealthchop_threshold: 5
+
+########################################
+# TMC5160 configuration
+########################################
+
+[tmc5160 stepper_x]
+cs_pin: PA15
+spi_software_miso_pin: PC11
+spi_software_mosi_pin: PC12
+spi_software_sclk_pin: PC10
+diag1_pin: !PB10
+run_current: 0.850
+hold_current: 0.500
+driver_SGT: 0 #5
+stealthchop_threshold: 250
+sense_resistor = 0.075
+
+[tmc5160 stepper_y]
+cs_pin: PB8
+spi_software_miso_pin: PC11
+spi_software_mosi_pin: PC12
+spi_software_sclk_pin: PC10
+diag1_pin: !PE12
+run_current: 0.850
+hold_current: 0.500
+driver_SGT: 0 #5
+stealthchop_threshold: 250
+sense_resistor = 0.075
+
+[tmc5160 extruder]
+cs_pin: PB3
+spi_software_miso_pin: PC11
+spi_software_mosi_pin: PC12
+spi_software_sclk_pin: PC10
+diag1_pin: PE15
+run_current: 0.450
+hold_current: 0.400
+stealthchop_threshold: 0
+sense_resistor = 0.075
+
+#####################################################################
+# Heaters
+#####################################################################
+
+[extruder]
+step_pin: PE14
+dir_pin: PA0
+enable_pin: !PC3
+##	Update value below when you perform extruder calibration
+##	If you ask for 100mm of filament, but in reality it is 98mm:
+##	rotation_distance = <previous_rotation_distance> * <actual_extrude_distance> / 100
+##  22.6789511 is a good starting point
+rotation_distance: 22.6789511	#Bondtech 5mm Drive Gears
+##	Update Gear Ratio depending on your Extruder Type
+##	Use 50:17 for Afterburner/Clockwork (BMG Gear Ratio)
+##	Use 80:20 for M4, M3.1
+microsteps: 16
+nozzle_diameter: 0.400
+filament_diameter: 1.750
+gear_ratio: 50:17
+heater_pin: PB1 # Heat0
+sensor_pin:  PF4 # T1 Header
+sensor_type: ATC Semitec 104NT-4-R025H42G #ATC Semitec 104GT-2 #EPCOS 100K B57560G104F
+#control: pid
+#pid_Kp: 22.2
+#pid_Ki: 1.08
+#pid_Kd: 114
+min_temp: -20
+max_temp: 400
+max_extrude_only_distance: 100.0
+#   Maximum length (in mm of raw filament) that a retraction or
+#   extrude-only move may have. If a retraction or extrude-only move
+#   requests a distance greater than this value it will cause an error
+#   to be returned. The default is 50mm.
+max_extrude_cross_section: .8
+#   Maximum area (in mm^2) of an extrusion cross section (eg,
+#   extrusion width multiplied by layer height). This setting prevents
+#   excessive amounts of extrusion during relatively small XY moves.
+#   If a move requests an extrusion rate that would exceed this value
+#   it will cause an error to be returned. The default is: 4.0 *
+#   nozzle_diameter^2
+##	Try to keep pressure_advance below 1.0
+pressure_advance: 0.0845 #(16.9*.005) #0.338 #(16.9*.020)prusament petg #0.05
+##	Default is 0.040, leave stock
+pressure_advance_smooth_time: 0.040
+
+[heater_bed]
+## SSR
+heater_pin: PD12
+sensor_pin: PF3 # T0
+sensor_type: ATC Semitec 104GT-2
+##	Adjust Max Power so your heater doesn't warp your bed
+max_power: 0.6
+min_temp: -273 #Fix
+max_temp: 120
+control: pid
+pid_kp: 58.437
+pid_ki: 2.347
+pid_kd: 363.769
+
+[thermistor ATC Semitec 104NT-4-R025H42G]
+temperature1:   -20
+resistance1:    4018000
+temperature2:   250
+resistance2:    1591
+temperature3:   500
+resistance3:    101.1
+#   Three resistance measurements (in Ohms) at the given temperatures
+#   (in Celsius). The three measurements will be used to calculate the
+#   Steinhart-Hart coefficients for the thermistor. These parameters
+#   must be provided when using Steinhart-Hart to define the
+#   thermistor.
+#beta:
+#   Alternatively, one may define temperature1, resistance1, and beta
+#   to define the thermistor parameters. This parameter must be
+#   provided when using "beta" to define the thermistor.
+
+#####################################################################
+# 	Fan Control
+#####################################################################
+
+[heater_fan hotend_fan] #fan0
+pin: PC8
+heater: extruder
+heater_temp: 50.0
+##	If you are experiencing back flow, you can reduce fan_speed
+#fan_speed: 1.0
+
+[fan] #fan1
+##	Print Cooling Fan
+pin: PE5
+max_power: .49
+#   The maximum power (expressed as a value from 0.0 to 1.0) that the
+#   pin may be set to. The value 1.0 allows the pin to be set fully
+#   enabled for extended periods, while a value of 0.5 would allow the
+#   pin to be enabled for no more than half the time. This setting may
+#   be used to limit the total power output (over extended periods) to
+#   the fan. If this value is less than 1.0 then fan speed requests
+#   will be scaled between zero and max_power (for example, if
+#   max_power is .9 and a fan speed of 80% is requested then the fan
+#   power will be set to 72%). The default is 1.0.
+
+[heater_fan exhaust_fan] #fan2
+pin: PE6
+heater: heater_bed
+heater_temp: 60
+
+#####################################################################
+# 	LED Control
+#####################################################################
+
+#[output_pin caselight]
+# Chamber Lighting - Bed Connector (Optional)
+#pin: P2.5
+#pwm:true
+#shutdown_value: 0
+#value:100
+#cycle_time: 0.01
+
+#######################################################
+# Input Shaper
+#######################################################
+
+[adxl345]
+cs_pin: rpi:None
+
+[resonance_tester]
+accel_chip: adxl345
+probe_points:
+    150,150,150  # an example
+
+[input_shaper]
+shaper_type_x = ei      #zv
+shaper_freq_x = 65.4    #71.6
+shaper_type_y = zv
+shaper_freq_y = 54.8
+
+#shaper_freq_x: 46.8
+#shaper_type_x: ei
+
+#######################################################
+# MCU
+#######################################################
+
+[mcu rpi]
+serial: /tmp/klipper_host_mcu
+
+[mcu]
+serial: /dev/serial/by-id/usb-Klipper_stm32f407xx_28004D000E504D5347343820-if00
+########################################
+# EXP1 / EXP2 (display) pins
+########################################
+
+[board_pins]
+aliases:
+    # EXP1 header
+    EXP1_1=PG4, EXP1_3=PD11, EXP1_5=PG2, EXP1_7=PG6, EXP1_9=<GND>,
+    EXP1_2=PA8, EXP1_4=PD10, EXP1_6=PG3, EXP1_8=PG7, EXP1_10=<5V>,
+    # EXP2 header
+    EXP2_1=PB14, EXP2_3=PG10, EXP2_5=PF11, EXP2_7=PF12,  EXP2_9=<GND>,
+    EXP2_2=PB13, EXP2_4=PB12, EXP2_6=PB15, EXP2_8=<RST>, EXP2_10=PF13
+    # Pins EXP2_1, EXP2_6, EXP2_2 are also MISO, MOSI, SCK of bus "spi2"
+# See the sample-lcd.cfg file for definitions of common LCD displays.
+
+###################################################
+# extras
+###################################################
+
+[safe_z_home]
+##	XY Location of the Z Endstop Switch
+##	Update -10,-10 to the XY coordinates of your endstop pin 
+##	(such as 157,305) after going through Z Endstop Pin
+##	Location Definition step.
+home_xy_position: 203,299
+speed:100
+z_hop:20
+
+#####################################################################
+# 	Probe
+#####################################################################
+
+[probe]
+##	Inductive Probe
+##	This probe is not used for Z height, only Quad Gantry Leveling
+##	Z_MAX on mcu_z
+##	If your probe is NO instead of NC, add change pin to !z:P0.10
+pin: PA1
+x_offset: 0
+y_offset: 25.0
+#z_offset: -3.067 #-1.687 #-1.380 #-0.087
+speed: 10.0 #10.0
+samples: 3
+samples_result: median
+sample_retract_dist: 1.0
+samples_tolerance: 0.006
+samples_tolerance_retries: 3
+
+[quad_gantry_level]
+#   Use QUAD_GANTRY_LEVEL to level a gantry.
+# ----------------
+# |Z1          Z2|
+# |  ---------   |
+# |  |       |   |
+# |  |       |   |
+# |  x--------   |
+# |Z           Z3|
+# ----------------
+
+gantry_corners:
+   -60,-10
+   360,370
+#   Min & Max gantry corners - measure from nozzle at MIN (0,0) and MAX (300,300) to respective belt positions
+points:
+   50,25
+   50,225
+   250,225
+   250,25
+#   Probe points
+speed: 200
+#   The speed (in mm/s) of non-probing moves during the calibration.
+#   The default is 50.
+horizontal_move_z: 5
+#   The height (in mm) that the head should be commanded to move to
+#   just prior to starting a probe operation. The default is 5
+retries: 5
+#   number of times to retry if the stepper movements aren't within tolerance
+retry_tolerance: 0.0075
+#   if retries are enabled then retry if any z_stepper movement was greater
+#   than the retry_tolerance
+max_adjust: 10
+
+[bed_mesh]
+speed: 100
+horizontal_move_z: 5
+mesh_min: 20,25
+mesh_max: 280, 250
+probe_count: 5,5
+relative_reference_index: 5
+fade_start: 1
+fade_end: 5
+fade_target: 0
+
+[idle_timeout]
+timeout: 1800
+   
+[force_move]
+enable_force_move: True
+#   Set to true to enable FORCE_MOVE and SET_KINEMATIC_POSITION
+#   extended G-Code commands. The default is false.
+
+#####################################################################
+# 	Macros
+#####################################################################
+
+[gcode_macro G32]
+gcode:
+    BED_MESH_CLEAR
+    G28 X Y
+    G28
+    G1 X150 Y 150 Z20
+    QUAD_GANTRY_LEVEL
+    G28 X Y
+    G28
+    ##	Uncomment for for your size printer:
+    #--------------------------------------------------------------------
+    ##	Uncomment for 250mm build
+    #G0 X125 Y125 Z30 F3600
+    
+    ##	Uncomment for 300 build
+    G0 X150 Y150 Z30 F3600
+    
+    ##	Uncomment for 350mm build
+    #G0 X175 Y175 Z30 F3600
+    #--------------------------------------------------------------------
+    BED_MESH_PROFILE LOAD=default
+ 
+[gcode_macro PRINT_START]
+#   Use PRINT_START for the slicer starting script - please customise for your slicer of choice
+gcode:
+    G32                            ; home all axes
+    G1 Z20 F3000                   ; move nozzle away from bed
+
+[gcode_macro PRINT_END]
+#   Use PRINT_END for the slicer ending script - please customise for your slicer of choice
+gcode:
+    M400                           ; wait for buffer to clear
+    G92 E0                         ; zero the extruder
+    G1 E-10.0 F3600                ; retract filament
+    G91                            ; relative positioning
+    G0 Z1.00 X20.0 Y20.0 F20000    ; move nozzle to remove stringing
+    TURN_OFF_HEATERS
+    M107                           ; turn off fan
+    G1 Z2 F3000                    ; move nozzle up 2mm
+    G90                            ; absolute positioning
+    G0  X125 Y250 F3600            ; park nozzle at rear
+    BED_MESH_CLEAR
+
+## 	Thermistor Types
+##   "EPCOS 100K B57560G104F"
+##   "ATC Semitec 104GT-2"
+##   "NTC 100K beta 3950"
+##   "Honeywell 100K 135-104LAG-J01"
+##   "NTC 100K MGB18-104F39050L32" (Keenovo Heater Pad)
+##   "AD595"
+##   "PT100 INA826"
+
+#*# <---------------------- SAVE_CONFIG ---------------------->
+#*# DO NOT EDIT THIS BLOCK OR BELOW. The contents are auto-generated.
+#*#
+#*# [bed_mesh default]
+#*# version = 1
+#*# points =
+#*# 	  -0.177500, 0.050000, 0.025000, -0.010000, -0.015000
+#*# 	  -0.145000, 0.082500, 0.050000, 0.005000, 0.000000
+#*# 	  -0.142500, 0.092500, 0.062500, -0.015000, 0.010000
+#*# 	  -0.157500, 0.095000, 0.072500, -0.005000, 0.020000
+#*# 	  -0.185000, 0.085000, 0.052500, -0.030000, -0.012500
+#*# tension = 0.2
+#*# min_x = 20.0
+#*# algo = lagrange
+#*# y_count = 5
+#*# mesh_y_pps = 2
+#*# min_y = 25.0
+#*# x_count = 5
+#*# max_y = 250.0
+#*# mesh_x_pps = 2
+#*# max_x = 280.0
+#*#
+#*# [bed_mesh Test]
+#*# version = 1
+#*# points =
+#*# 	-0.192500, 0.047500, 0.022500, -0.007500, -0.015000
+#*# 	-0.150000, 0.087500, 0.057500, 0.002500, 0.000000
+#*# 	-0.140000, 0.102500, 0.072500, -0.005000, 0.025000
+#*# 	-0.155000, 0.105000, 0.080000, -0.005000, 0.017500
+#*# 	-0.187500, 0.090000, 0.052500, -0.027500, -0.015000
+#*# tension = 0.2
+#*# min_x = 20.0
+#*# algo = lagrange
+#*# y_count = 5
+#*# mesh_y_pps = 2
+#*# min_y = 25.0
+#*# x_count = 5
+#*# max_y = 250.0
+#*# mesh_x_pps = 2
+#*# max_x = 280.0
+#*#
+#*# [extruder]
+#*# control = pid
+#*# pid_kp = 30.244
+#*# pid_ki = 2.016
+#*# pid_kd = 113.416
+#*#
+#*# [probe]
+#*# z_offset = -0.087


### PR DESCRIPTION
This is my current CFG for a V2.4 300 using a SKR PRO 1.1 with a MOT using 2208s for Z and 5160s for X, Y and Extruder.

This is also configured for sensorless homing on the AB motors.